### PR TITLE
Update EOS download version 1.7.3 -> 1.8.6

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -8,7 +8,7 @@ RUN echo "INSTALLING EOSIO AND CDT" \
  && apt-get install -y wget sudo curl \
  && wget https://github.com/EOSIO/eosio.cdt/releases/download/v1.6.1/eosio.cdt_1.6.1-1_amd64.deb \
  && apt-get update && sudo apt install -y --allow-downgrades ./eosio.cdt_1.6.1-1_amd64.deb \
- && wget https://github.com/EOSIO/eos/releases/download/v1.7.3/eosio_1.7.3-1-ubuntu-18.04_amd64.deb \
- && apt-get update && sudo apt install -y ./eosio_1.7.3-1-ubuntu-18.04_amd64.deb \
- && rm ./eosio_1.7.3-1-ubuntu-18.04_amd64.deb \
+ && wget https://github.com/EOSIO/eos/releases/download/v1.8.6/eosio_1.8.6-1-ubuntu-18.04_amd64.deb \
+ && apt-get update && sudo apt install -y ./eosio_1.8.6-1-ubuntu-18.04_amd64.deb \
+ && rm ./eosio_1.8.6-1-ubuntu-18.04_amd64.deb \
  && rm ./eosio.cdt_1.6.1-1_amd64.deb

--- a/eosio/Dockerfile
+++ b/eosio/Dockerfile
@@ -4,8 +4,8 @@ RUN echo "INSTALLING EOSIO AND CDT"
 RUN apt-get update && apt-get install -y wget sudo curl
 RUN wget https://github.com/EOSIO/eosio.cdt/releases/download/v1.6.1/eosio.cdt_1.6.1-1_amd64.deb
 RUN apt-get update && sudo apt install -y ./eosio.cdt_1.6.1-1_amd64.deb
-RUN wget https://github.com/EOSIO/eos/releases/download/v1.7.3/eosio_1.7.3-1-ubuntu-18.04_amd64.deb
-RUN apt-get update && sudo apt install -y ./eosio_1.7.3-1-ubuntu-18.04_amd64.deb
+RUN wget https://github.com/EOSIO/eos/releases/download/v1.8.6/eosio_1.8.6-1-ubuntu-18.04_amd64.deb
+RUN apt-get update && sudo apt install -y ./eosio_1.8.6-1-ubuntu-18.04_amd64.deb
 
 RUN echo "INSTALLING CONTRACTS"
 RUN mkdir -p "/opt/eosio/bin/contracts"


### PR DESCRIPTION
## Change Description
GitPod/local instances do not run due to the error in the following screenshot. This is fixed by updating the version of EOS that is downloaded from 1.7.3 to 1.8.6.

<img width="933" alt="Screen Shot 2019-12-03 at 9 33 30 AM" src="https://user-images.githubusercontent.com/11666182/70071083-c586b580-15c2-11ea-80bb-37781f51e4fb.png">


## API Changes
- [ ] API Changes


## Documentation Additions
- [ ] Documentation Additions
